### PR TITLE
FIX: make plot in mono notebook "live"

### DIFF
--- a/X-ray Absorption Fine Structure/Monochrometer Optimization.ipynb
+++ b/X-ray Absorption Fine Structure/Monochrometer Optimization.ipynb
@@ -62,6 +62,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "plt.figure(num='I0 signal vs. DCM 2nd crystal pitch')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "RE(rocking_curve())"
    ]
   },
@@ -161,7 +170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/X-ray Absorption Fine Structure/simulated_hardware.py
+++ b/X-ray Absorption Fine Structure/simulated_hardware.py
@@ -19,5 +19,5 @@ def compute_I0():
 
 pitch = SynAxis(name="pitch")
 pitch.set(4).wait()  # initialize at a reasonable value
-# pitch.delay = 0.05  # to simulate movement time
+pitch.delay = 0.05  # to simulate movement time
 I0 = SynSignal(name="I0", func=compute_I0)


### PR DESCRIPTION
When creating a Figure at least one message needs to make it from the
front end to the kernel.  However, the kernel can not process that
message until the cell you create in figure in has returned.  To make
the figure "live" in the notebook pre-create it with the agreed on name.