### PR TITLE
MNT: add missing standard aliases for bp, bps, bpp

### DIFF
--- a/scripts/beamline_configuration.py
+++ b/scripts/beamline_configuration.py
@@ -64,12 +64,15 @@ import bluesky.callbacks
 from bluesky.callbacks import *
 
 import bluesky.plans
+import bluesky.plans as bp
 from bluesky.plans import *
 
 import bluesky.plan_stubs
+import bluesky.plan_stubs as bps
 from bluesky.plan_stubs import *
 
 import bluesky.preprocessors
+import bluesky.preprocessors as bpp
 import bluesky.simulators
 from bluesky.simulators import *
 


### PR DESCRIPTION
Even if you don't want to teach these, I find it maddening for these to not be available when debugging.