### PR TITLE
Maybe installing netifaces removes need for env vars.

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,5 +1,5 @@
 bluesky
-caproto >=0.5.0
+caproto[standard] >=0.5.0
 dask
 databroker >=1.0.3
 distributed


### PR DESCRIPTION
This branch should be tested on mybinder.org before merging.