### PR TITLE
Use PNG figures.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,7 +59,7 @@ nbsphinx_prolog = """
 """
 
 nbsphinx_execute_arguments = [
-    "--InlineBackend.figure_formats={'svg', 'pdf'}",
+    "--InlineBackend.figure_formats={'png'}",
     "--InlineBackend.rc={'figure.dpi': 96}",
 ]
 


### PR DESCRIPTION
The latest build on `master`, the first such build after merging #53, failed to push to GH pages and generated error messages like

```
remote: error: GH001: Large files detected. You may want to try Git Large File Storage - https://git-lfs.github.com.        
remote: error: Trace: b8a5903f2b9fa47a0a4101f15cb31e8b        
remote: error: See http://git.io/iEPt8g for more information.        
remote: error: File tutorials/Higher Dimensional Data.ipynb is 442.79 MB; this exceeds GitHub's file size limit of 100.00 MB        
remote: error: File tutorials/Multi-dimensional Coordinates.ipynb is 500.39 MB; this exceeds GitHub's file size limit of 100.00 MB        
remote: error: File tutorials/_images/Higher_Dimensional_Data_29_2.svg is 237.88 MB; this exceeds GitHub's file size limit of 100.00 MB        
remote: error: File tutorials/Slice and Interpolate Image Data.ipynb is 200.20 MB; this exceeds GitHub's file size limit of 100.00 MB      
```

I suspect that the issue is that we are forcing rasterized images to be rendered as SVG, and that is not space-efficient. This PR moves everything to PNG. I would be ideal if we could do SVG and PNG selectively, but that's a problem for another day.