### PR TITLE
Refactor to use SingleRunCache.

### DIFF
--- a/X-ray Absorption Fine Structure/Monochromator Optimization.ipynb
+++ b/X-ray Absorption Fine Structure/Monochromator Optimization.ipynb
@@ -455,7 +455,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.5"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,

--- a/X-ray Absorption Fine Structure/plans.py
+++ b/X-ray Absorption Fine Structure/plans.py
@@ -7,7 +7,7 @@ import pandas
 from scipy.ndimage import center_of_mass
 import matplotlib.pyplot as plt
 
-from databroker.core import SingleRunCache, parse_transforms
+from databroker.core import SingleRunCache
 
 from simulated_hardware import pitch, I0
 

--- a/X-ray Absorption Fine Structure/plans.py
+++ b/X-ray Absorption Fine Structure/plans.py
@@ -1,4 +1,4 @@
-from bluesky.plan_stubs import mv, subscribe, unsubscribe
+from bluesky.plan_stubs import mv
 from bluesky.plans import rel_scan
 from bluesky.preprocessors import subs_decorator
 from bluesky.callbacks.mpl_plotting import LivePlot
@@ -57,7 +57,9 @@ def rocking_curve(start=-0.10, stop=0.10, nsteps=101, choice="peak"):
         )
         uid = yield from rel_scan([I0], pitch, start, stop, nsteps)
 
-        # Access the data that we just collected.
+        # The data that we just acquired has been cached in memory by src.
+        # Access it as a pandas DataFrame so that we can conveniently do some
+        # math on it.
         run = src.retrieve()
         t = run.primary.read().to_dataframe()
         signal = t["I0"]
@@ -82,5 +84,5 @@ def rocking_curve(start=-0.10, stop=0.10, nsteps=101, choice="peak"):
         )
         print(f"Found and moved to peak at {top:.3} via method {choice}")
         yield from mv(pitch, top)
-    
+
     yield from scan_dcm_pitch()


### PR DESCRIPTION
In the original implementation copied from BMM, the plan held a reference to
``db`` and used it to load the data. In the current ``master`` branch, we use
something that I sketched up to collect the data as it comes it via a
subscription, and then access it as a pandas data structure. That sketch
has been refined and released in databroker v1.0.3 as `SingleRunCache`. This
simplfied the code in the plan considerably and keeps the focus on the
important parts.

attn @bruceravel