### PR TITLE
make the links look better in fly tutorial

### DIFF
--- a/Flyer Basics.ipynb
+++ b/Flyer Basics.ipynb
@@ -348,7 +348,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Still only two `documents` were emitted from the `RunEngine`"
+    "Still only three `documents` were emitted from the `RunEngine`: `start`, `descriptor`, and `stop`."
    ]
   },
   {
@@ -550,7 +550,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, there are two more document types emitted: `descriptor` and `event`.  Only one `event` since there is only one data point."
+    "Now, there is one more document type emitted: `event`.  Only one `event` since there is only one data point."
    ]
   },
   {

--- a/Flyer Basics.ipynb
+++ b/Flyer Basics.ipynb
@@ -23,7 +23,7 @@
     "Links\n",
     "\n",
     "* USAXS fly scan - https://github.com/APS-USAXS/ipython-usaxs/issues/3\n",
-    "* `databroker.temp()` - https://nsls-ii.github.io/databroker/v1/api.html\n"
+    "* `databroker.temp()` - https://blueskyproject.io/databroker/v1/api.html\n"
    ]
   },
   {
@@ -67,12 +67,12 @@
     "\n",
     "Links\n",
     "\n",
-    "* *Flyer* - https://nsls-ii.github.io/bluesky/async.html?highlight=flyer#flying\n",
-    "* `ophyd.Device` - https://nsls-ii.github.io/ophyd/device-overview.html\n",
-    "* *Fly-able interface* - https://nsls-ii.github.io/ophyd/architecture.html#fly-able-interface\n",
-    "* returns - https://nsls-ii.github.io/bluesky/hardware.html#kickoff\n",
-    "* `ophyd.status.Status` - https://nsls-ii.github.io/ophyd/generated/ophyd.status.Status.html\n",
-    "* `DeviceStatus()` - https://nsls-ii.github.io/ophyd/generated/ophyd.status.DeviceStatus.html\n",
+    "* *Flyer* - https://blueskyproject.io/bluesky/async.html?highlight=flyer#flying\n",
+    "* `ophyd.Device` - https://blueskyproject.io/ophyd/device-overview.html\n",
+    "* *Fly-able interface* - https://blueskyproject.io/ophyd/architecture.html#fly-able-interface\n",
+    "* returns - https://blueskyproject.io/bluesky/hardware.html#kickoff\n",
+    "* `ophyd.status.Status` - https://blueskyproject.io/ophyd/generated/ophyd.status.Status.html\n",
+    "* `DeviceStatus()` - https://blueskyproject.io/ophyd/generated/ophyd.status.DeviceStatus.html\n",
     "* discussion - https://github.com/NSLS-II/tutorial-docker/pull/7#discussion_r185054364"
    ]
   },

--- a/Flyer Basics.ipynb
+++ b/Flyer Basics.ipynb
@@ -10,17 +10,20 @@
     "\n",
     "The basic notion of a Flyer is that it directs an *external controller* (we'll call it the *controller* here) to perform some data collection process.  Usually, a *controller* is used to collect data at rates beyond the capabilities of Bluesky plans and the RunEngine.  Examples could be waveforms from a storage oscilloscope or a continuous motion scan of a diffractometer.\n",
     "\n",
-    "This notebook will show the basic requirements for a Flyer and build a simple working example you can use a template for your own work.  (Our inspiration to create this [basic flyer tutorial](https://github.com/prjemian/ipython_mintvm/issues/3#issuecomment-385058577) was the goal of operating various fly scans at the APS, such as the [USAXS fly scan](https://github.com/APS-USAXS/ipython-usaxs/issues/3), from Bluesky.  The examples we found before we started this project quickly became too instrument-specific to serve as tutorials.)\n",
-    "\n",
-    "\n",
+    "This notebook will show the basic requirements for a Flyer and build a simple working example you can use a template for your own work.  (Our inspiration to create this [basic flyer tutorial](https://github.com/prjemian/ipython_mintvm/issues/3#issuecomment-385058577) was the goal of operating various fly scans at the APS, such as the USAXS fly scan, from Bluesky.  The examples we found before we started this project quickly became too instrument-specific to serve as tutorials.)\n",
     "## Python imports and definitions \n",
     "\n",
     "Here are the full set of packages to imported.  The first block are Python standard packages, then come the ophyd, Bluesky, and databroker packages.  Just the parts we plan on using here.  Since this is also a tutorial, we will not rename imports or use other such shortcuts in the documentation (the online code has some shortcuts).\n",
     "\n",
     "* Create a logger instance in case we want to investigate internal details as our code runs.\n",
     "* Create an instance of the Bluesky RunEngine.\n",
-    "* Create an instance of the databroker using [`databroker.temp()`](https://nsls-ii.github.io/databroker/v1/api.html), establishing a temporary, disposable yet fully-functional databroker for just this tutorial session.\n",
-    "* Subscribe that databroker instance to the RunEngine so it receives the document stream each time we run a plan.\n"
+    "* Create an instance of the databroker using `databroker.temp()`, establishing a temporary, disposable yet fully-functional databroker for just this tutorial session.\n",
+    "* Subscribe that databroker instance to the RunEngine so it receives the document stream each time we run a plan.\n",
+    "\n",
+    "Links\n",
+    "\n",
+    "* USAXS fly scan - https://github.com/APS-USAXS/ipython-usaxs/issues/3\n",
+    "* `databroker.temp()` - https://nsls-ii.github.io/databroker/v1/api.html\n"
    ]
   },
   {
@@ -50,17 +53,27 @@
    "source": [
     "### Bare Minimum Requirements for a Flyer <a class=\"anchor\" id=\"flyer-requirements\" />\n",
     "\n",
-    "In Bluesky, a [Flyer](http://nsls-ii.github.io/bluesky/async.html?highlight=flyer#flying) is an [`ophyd.Device`](http://nsls-ii.github.io/ophyd/device-overview.html) that meets the [Fly-able interface](http://nsls-ii.github.io/ophyd/architecture.html#fly-able-interface), which has three methods:\n",
+    "In Bluesky, a *Flyer* is an `ophyd.Device` that meets the *Fly-able interface*, which has three methods:\n",
     "\n",
     "1. Kickoff - begin accumulating data\n",
     "1. Complete - Bluesky tells the Flyer that Bluesky is ready to receive data\n",
     "1. Collect - the device provides the data to Bluesky\n",
     "\n",
-    "The first two methods [must return](http://nsls-ii.github.io/bluesky/hardware.html#kickoff) an instance of [`ophyd.status.Status`](http://nsls-ii.github.io/ophyd/generated/ophyd.status.Status.html) (a.k.a. a *status* object).  For our code, we choose a specialized version of `Status()`, the [`DeviceStatus()`](http://nsls-ii.github.io/ophyd/generated/ophyd.status.DeviceStatus.html) object, based on the [explanation provided in discussion](https://github.com/NSLS-II/tutorial-docker/pull/7#discussion_r185054364).\n",
+    "The first two methods must return an instance of `ophyd.status.Status` (a.k.a. a *status* object).  For our code, we choose a specialized version of `Status()`, the `DeviceStatus()` object, based on the explanation provided in discussion.\n",
     "\n",
     "The `collect()` method requires a companion `describe_collect()` that informs the RunEngine what kind of data to expect from `collect()`.  If no timestamp information is provided from the *controller*, then do as we show here and use the workstation's clock to provide a timestamp for the event.\n",
     "\n",
-    "This example (which does absolutely nothing) meets the bare minimum requirement."
+    "This example (which does absolutely nothing) meets the bare minimum requirement.\n",
+    "\n",
+    "Links\n",
+    "\n",
+    "* *Flyer* - https://nsls-ii.github.io/bluesky/async.html?highlight=flyer#flying\n",
+    "* `ophyd.Device` - https://nsls-ii.github.io/ophyd/device-overview.html\n",
+    "* *Fly-able interface* - https://nsls-ii.github.io/ophyd/architecture.html#fly-able-interface\n",
+    "* returns - https://nsls-ii.github.io/bluesky/hardware.html#kickoff\n",
+    "* `ophyd.status.Status` - https://nsls-ii.github.io/ophyd/generated/ophyd.status.Status.html\n",
+    "* `DeviceStatus()` - https://nsls-ii.github.io/ophyd/generated/ophyd.status.DeviceStatus.html\n",
+    "* discussion - https://github.com/NSLS-II/tutorial-docker/pull/7#discussion_r185054364"
    ]
   },
   {
@@ -125,10 +138,14 @@
     "        self.kickoff_status = None\n",
     "        self.complete_status = None\n",
     "\n",
-    "Our *controller* could take some time to signal that it is finished (seconds to minutes, at least).  We need a way to detect this completion.  We can do that either by polling the PV or by subscribing to a callback on the completion event.  We'll make that choice when we implement the actual activity.  Here, intend to wait in a polling loop.  Since the polling loop is an activity that does not return until the *controller* is done, we must do that waiting in a thread (consider an [alternative suggestion to use `epics.ca.CAThread`](https://github.com/NSLS-II/tutorial-docker/pull/7#discussion_r184905960)) separate from that of the RunEngine.  (We do not want to block the RunEngine thread so it is free to respond to other activities, such as data from other streams or the user inerface.)  So, we run `my_activity()` in a separate thread that is called from `kickoff()`:\n",
+    "Our *controller* could take some time to signal that it is finished (seconds to minutes, at least).  We need a way to detect this completion.  We can do that either by polling the PV or by subscribing to a callback on the completion event.  We'll make that choice when we implement the actual activity.  Here, intend to wait in a polling loop.  Since the polling loop is an activity that does not return until the *controller* is done, we must do that waiting in a thread (consider an [alternative suggestion to use `epics.ca.CAThread` separate from that of the RunEngine.  (We do not want to block the RunEngine thread so it is free to respond to other activities, such as data from other streams or the user inerface.)  So, we run `my_activity()` in a separate thread that is called from `kickoff()`:\n",
     "\n",
     "        thread = threading.Thread(target=self.my_activity, daemon=True)\n",
     "        thread.start()\n",
+    "\n",
+    "Link\n",
+    "\n",
+    "* `epics.ca.CAThread` - https://github.com/NSLS-II/tutorial-docker/pull/7#discussion_r184905960\n",
     "\n",
     "The basic outline of `my_activity()` is:\n",
     "\n",
@@ -750,9 +767,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.7.7 64-bit ('bluesky_2020_5': conda)",
    "language": "python",
-   "name": "python3"
+   "name": "python37764bitbluesky20205conda414c31c00fba48028d4852f6340d7af7"
   },
   "language_info": {
    "codemirror_mode": {
@@ -764,7 +781,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.7-final"
   }
  },
  "nbformat": 4,

--- a/Flyer Basics.ipynb
+++ b/Flyer Basics.ipynb
@@ -113,7 +113,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Only two `documents` were emitted from the `RunEngine`: `start` and `stop` since we generated no data content."
+    "Only three `documents` were emitted from the `RunEngine`: `start`, `descriptor`, and `stop` since we generated no data content."
    ]
   },
   {

--- a/Flyer Basics.ipynb
+++ b/Flyer Basics.ipynb
@@ -767,9 +767,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.7 64-bit ('bluesky_2020_5': conda)",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python37764bitbluesky20205conda414c31c00fba48028d4852f6340d7af7"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
ReST does not handle nested formatting.  When formatted links from markdown are processed by nbsphinx, they appear broken.  This will FIX #69.  It's not as pretty but we are working through several interfaces of automated text processing here.  ReST syntax is lowest common denominator.