### PR TITLE
Fix trigger_with_pc configuration

### DIFF
--- a/Device.ipynb
+++ b/Device.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "source": [
     "## Simulated Hardware\n",
-    "Below, we will connect to EPICS IOC(s) controlling simulated hardware in lieu of actual motors, detectors. The IOCs should already be running in the background. Run this command to verify that they are running: it should produce output with RUNNING on each line. In the event of a problem, edit this command to replace `status` with `restart all` and run again."
+    "Below, we will connect to EPICS IOC(s) controlling simulated hardware in lieu of actual motors, detectors. The IOCs may already be running in the background. Run this command to ensure that they are running. In the event of a problem, edit this command to replace `status` with `restart all` and run again."
    ]
   },
   {
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!supervisorctl -c supervisor/supervisord.conf status"
+    "!./supervisor/start_supervisor.sh status"
    ]
   },
   {
@@ -1170,7 +1170,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/supervisor/conf.d/trigger_with_pc.conf
+++ b/supervisor/conf.d/trigger_with_pc.conf
@@ -1,5 +1,5 @@
 [program:trigger_with_pc]
-command = /usr/bin/env python3 -m caproto.ioc_examples.trigger_with_pc -v --interfaces=0.0.0.0
+command = /usr/bin/env python3 -m caproto.ioc_examples.too_clever.trigger_with_pc -v --interfaces=0.0.0.0
 stdout_logfile = /tmp/trigger_with_pc_stdout.log
 stderr_logfile = /tmp/trigger_with_pc_stderr.log
 stopasgroup = true


### PR DESCRIPTION
Updates the module location of `trigger_with_pc` since it moved in caproto.

Also includes small tweak to Device notebook supervisord startup.