### PR TITLE
Transcribe ophyd tutorials

### DIFF
--- a/Group Signals into Devices.ipynb
+++ b/Group Signals into Devices.ipynb
@@ -1,11 +1,9 @@
 {
  "cells": [
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "capable-organizer",
+   "cell_type": "markdown",
+   "id": "embedded-guitar",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# Group Signals into Devices\n",
     "\n",
@@ -25,7 +23,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "accepting-magic",
+   "id": "lyric-franchise",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,7 +32,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "distinguished-master",
+   "id": "incomplete-motel",
    "metadata": {},
    "source": [
     "## Define a Custom Device\n",
@@ -60,7 +58,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "inappropriate-cardiff",
+   "id": "piano-titanium",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "coastal-saint",
+   "id": "processed-detector",
    "metadata": {},
    "source": [
     "Up to this point we haven't actually created any signals yet or connected\n",
@@ -87,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cardiac-notice",
+   "id": "hollow-clark",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +96,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "solid-pantyhose",
+   "id": "cross-luxury",
    "metadata": {},
    "source": [
     "It is *conventional* to name the Python variable on the left the same as the\n",
@@ -117,7 +115,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "micro-douglas",
+   "id": "cognitive-green",
    "metadata": {},
    "source": [
     "In the same way we can connect to the other IOC. We create a second instance of\n",
@@ -127,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "organizational-march",
+   "id": "military-landing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eligible-structure",
+   "id": "approved-freedom",
    "metadata": {},
    "source": [
     "## Use it with the Bluesky RunEngine\n",
@@ -150,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "auburn-execution",
+   "id": "saving-latter",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "worldwide-japanese",
+   "id": "sustainable-fourth",
    "metadata": {},
    "source": [
     "We can access the components of ``random_walk_horiz`` like ``random_walk_horiz.x``\n",
@@ -172,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "distant-disabled",
+   "id": "embedded-lincoln",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +181,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "worldwide-helmet",
+   "id": "discrete-semester",
    "metadata": {},
    "source": [
     "We can also read ``random_walk_horiz`` in its entirety as a unit, treating it as\n",
@@ -193,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "available-impact",
+   "id": "modular-vaccine",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "transsexual-usage",
+   "id": "fundamental-glass",
    "metadata": {},
    "source": [
     "## Assign a \"Kind\" to Components\n",
@@ -215,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "protective-graphics",
+   "id": "official-harvest",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +222,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "satellite-manchester",
+   "id": "composite-conversation",
    "metadata": {},
    "source": [
     "This is probably not necessary. Unless we have some reason to expect that it\n",
@@ -237,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "healthy-reservation",
+   "id": "interested-filter",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "individual-bargain",
+   "id": "thirty-beginning",
    "metadata": {},
    "source": [
     "As a shorthand, a string alias is also accepted and normalized to enum member of\n",
@@ -258,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "listed-pasta",
+   "id": "clear-heath",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +266,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "unlike-albania",
+   "id": "amazing-faculty",
    "metadata": {},
    "source": [
     "Equivalently, we could have set the ``kind`` when we first defined the device, like so:"
@@ -277,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "attempted-spokesman",
+   "id": "swiss-cruise",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +286,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "piano-latest",
+   "id": "guided-swing",
    "metadata": {},
    "source": [
     "Again, either enum ``Kind.config`` or string ``\"config\"`` are accepted.\n",
@@ -300,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "southern-coral",
+   "id": "faced-mortgage",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +308,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "french-variance",
+   "id": "nonprofit-volume",
    "metadata": {},
    "source": [
     "In Bluesky's Document Model, the result of ``device.read()`` is placed in an\n",
@@ -322,14 +320,6 @@
     "For a larger example of Kind being used on a real device,\n",
     "see [the source code for EpicsMotor](https://github.com/bluesky/ophyd/blob/master/ophyd/epics_motor.py)."
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "distinguished-salem",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/Group Signals into Devices.ipynb
+++ b/Group Signals into Devices.ipynb
@@ -1,0 +1,356 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "capable-organizer",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Group Signals into Devices\n",
+    "\n",
+    "In this tutorial we will group multiple Signals into a simple custom Device,\n",
+    "which enables us to conveniently connect to them and read them in batch.\n",
+    "\n",
+    "## Set up for tutorial\n",
+    "\n",
+    "We'll start our IOCs connected to simulated hardware.\n",
+    "Two implement a [random walk](https://en.wikipedia.org/wiki/Random_walk).\n",
+    "\n",
+    "The IOCs may already be running in the background. Run this command to verify\n",
+    "that they are running: it should produce output with STARTING or RUNNING on each line.\n",
+    "In the event of a problem, edit this command to replace `status` with `restart all` and run again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "accepting-magic",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!supervisor/start_supervisor.sh status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "distinguished-master",
+   "metadata": {},
+   "source": [
+    "## Define a Custom Device\n",
+    "\n",
+    "\n",
+    "It's common to have more than one instance of a given piece of hardware and to\n",
+    "present each instance in EPICS with different \"prefixes\" as in:\n",
+    "\n",
+    "```\n",
+    "# Device 1:\n",
+    "random-walk:horiz:dt\n",
+    "random-walk:horiz:x\n",
+    "\n",
+    "# Device 2:\n",
+    "random-walk:vert:dt\n",
+    "random-walk:vert:x\n",
+    "```\n",
+    "\n",
+    "Ophyd makes it easy to take advantage of the nested structure of PV string,\n",
+    "where applicable. Define a subclass of :class:`ophyd.Device`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "inappropriate-cardiff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ophyd import Component, Device, EpicsSignal, EpicsSignalRO\n",
+    "\n",
+    "class RandomWalk(Device):\n",
+    "   x = Component(EpicsSignalRO, 'x')\n",
+    "   dt = Component(EpicsSignal, 'dt')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "coastal-saint",
+   "metadata": {},
+   "source": [
+    "Up to this point we haven't actually created any signals yet or connected\n",
+    "to any hardware.  We have only *defined the structure* of this device and\n",
+    "provided the suffixes (``'x'``, ``'dt'``) of the relevant PVs.\n",
+    "\n",
+    "Now, we create an instance of the device, providing the PV prefix that\n",
+    "identifies one of our IOCs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cardiac-notice",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "random_walk_horiz = RandomWalk('random-walk:horiz:', name='random_walk_horiz')\n",
+    "random_walk_horiz.wait_for_connection()\n",
+    "random_walk_horiz"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "solid-pantyhose",
+   "metadata": {},
+   "source": [
+    "It is *conventional* to name the Python variable on the left the same as the\n",
+    "value of ``name``, but not required. That is, this is conventional...\n",
+    "\n",
+    "```\n",
+    "a = RandomWalk(\"...\", name=\"a\")\n",
+    "```\n",
+    "\n",
+    "```\n",
+    "a = RandomWalk(\"...\", name=\"b\")  # local variable different from name\n",
+    "a = RandomWalk(\"...\", name=\"some name with spaces in it\")\n",
+    "a = b = RandomWalk(\"...\", name=\"b\")  # two local variables\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "micro-douglas",
+   "metadata": {},
+   "source": [
+    "In the same way we can connect to the other IOC. We create a second instance of\n",
+    "the same class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "organizational-march",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "random_walk_vert = RandomWalk('random-walk:vert:', name='random_walk_vert')\n",
+    "random_walk_vert.wait_for_connection()\n",
+    "random_walk_vert"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eligible-structure",
+   "metadata": {},
+   "source": [
+    "## Use it with the Bluesky RunEngine\n",
+    "\n",
+    "The signals can be used by the Bluesky RunEngine. Let's configure a RunEngine\n",
+    "to print a table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "auburn-execution",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bluesky import RunEngine\n",
+    "from bluesky.callbacks import LiveTable\n",
+    "RE = RunEngine()\n",
+    "token = RE.subscribe(LiveTable([\"random_walk_horiz_x\", \"random_walk_horiz_dt\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "worldwide-japanese",
+   "metadata": {},
+   "source": [
+    "We can access the components of ``random_walk_horiz`` like ``random_walk_horiz.x``\n",
+    "and use this to read them individually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "distant-disabled",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bluesky.plans import count\n",
+    "\n",
+    "RE(count([random_walk_horiz.x], num=3, delay=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "worldwide-helmet",
+   "metadata": {},
+   "source": [
+    "We can also read ``random_walk_horiz`` in its entirety as a unit, treating it as\n",
+    "a composite \"detector\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "available-impact",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RE(count([random_walk_horiz], num=3, delay=1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "transsexual-usage",
+   "metadata": {},
+   "source": [
+    "## Assign a \"Kind\" to Components\n",
+    "\n",
+    "In the example just above, notice that we are recording ``random_walk_horiz_dt``\n",
+    "in every row (i.e. every Event) because it is returned alongside\n",
+    "``random_walk_horiz_x`` in the reading."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "protective-graphics",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "random_walk_horiz.read()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "satellite-manchester",
+   "metadata": {},
+   "source": [
+    "This is probably not necessary. Unless we have some reason to expect that it\n",
+    "could be changed, it would be more useful to record ``random_walk_horiz_dt``\n",
+    "once per Run as part of the device's *configuration*.\n",
+    "\n",
+    "Ophyd enables us to do this like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "healthy-reservation",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ophyd import Kind\n",
+    "\n",
+    "random_walk_horiz.dt.kind = Kind.config"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "individual-bargain",
+   "metadata": {},
+   "source": [
+    "As a shorthand, a string alias is also accepted and normalized to enum member of\n",
+    "that name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "listed-pasta",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "random_walk_horiz.dt.kind = \"config\"\n",
+    "random_walk_horiz.dt.kind"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "unlike-albania",
+   "metadata": {},
+   "source": [
+    "Equivalently, we could have set the ``kind`` when we first defined the device, like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "attempted-spokesman",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class RandomWalk(Device):\n",
+    "   x = Component(EpicsSignalRO, 'x')\n",
+    "   dt = Component(EpicsSignal, 'dt', kind=\"config\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "piano-latest",
+   "metadata": {},
+   "source": [
+    "Again, either enum ``Kind.config`` or string ``\"config\"`` are accepted.\n",
+    "\n",
+    "The result is that ``random_walk_horiz_dt`` is moved from ``read()`` to\n",
+    "``read_configuration()``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "southern-coral",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "random_walk_horiz.read()\n",
+    "random_walk_horiz.read_configuration()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "french-variance",
+   "metadata": {},
+   "source": [
+    "In Bluesky's Document Model, the result of ``device.read()`` is placed in an\n",
+    "Event Document, and the result of ``device.read_configuration()`` is placed in\n",
+    "an Event Descriptor document. The Bluesky RunEngine always calls\n",
+    "``device.read_configuration()`` and captures that information the first time\n",
+    "a given ``device`` is read.\n",
+    "\n",
+    "For a larger example of Kind being used on a real device,\n",
+    "see [the source code for EpicsMotor](https://github.com/bluesky/ophyd/blob/master/ophyd/epics_motor.py)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "distinguished-salem",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/Single PVs.ipynb
+++ b/Single PVs.ipynb
@@ -1,0 +1,500 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "great-wiring",
+   "metadata": {},
+   "source": [
+    "# Single EPICS PVs\n",
+    "\n",
+    "In this tutorial we will read, write, and monitor an EPICS PV in ophyd.\n",
+    "\n",
+    "Set up for tutorial\n",
+    "-------------------\n",
+    "\n",
+    "We'll start our IOCs connected to simulated hardware.\n",
+    "One implements a [random walk](https://en.wikipedia.org/wiki/Random_walk). It has\n",
+    "just two PVs. One is a tunable parameter, ``random_walk:dt``, the time between\n",
+    "steps. The other is ``random_walk:x``, the current position of the random\n",
+    "walker.\n",
+    "\n",
+    "The IOCs may already be running in the background. Run this command to verify that they are running: it should produce output with STARTING or RUNNING on each line. In the event of a problem, edit this command to replace `status` with `restart all` and run again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "vietnamese-blocking",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!supervisor/start_supervisor.sh status"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "august-mediterranean",
+   "metadata": {},
+   "source": [
+    "Connect to a PV from Ophyd\n",
+    "--------------------------\n",
+    "\n",
+    "Let's connect to the PV ``random_walk:dt`` from Ophyd. We need two pieces of\n",
+    "information:\n",
+    "\n",
+    "* The PV name, ``random_walk:dt``.\n",
+    "* A human-friendly name. This name is used to label the readings and will be\n",
+    "  used in any downstream data analysis or file-writing code. We might choose,\n",
+    "  for example, ``time_delta``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "photographic-right",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ophyd.signal import EpicsSignal\n",
+    "\n",
+    "time_delta = EpicsSignal(\"random_walk:dt\", name=\"time_delta\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "tested-detection",
+   "metadata": {},
+   "source": [
+    "It is *conventional* to name the Python variable on the left the same as the\n",
+    "value of ``name``, but not required. That is, this is conventional...\n",
+    "\n",
+    "\n",
+    "      a = EpicsSignal(\"...\", name=\"a\")\n",
+    "\n",
+    "...but all of these are also allowed.\n",
+    "\n",
+    "\n",
+    "      a = EpicsSignal(\"...\", name=\"b\")  # local variable different from name\n",
+    "      a = EpicsSignal(\"...\", name=\"some name with spaces in it\")\n",
+    "      a = b = EpicsSignal(\"...\", name=\"b\")  # two local variables\n",
+    "\n",
+    "Next let's connect to ``random_walk:x``. It happens that this PV is not\n",
+    "writable---any writes would be rejected by EPICS---so we should use a read-only\n",
+    "EpicsSignal, `ophyd.signal.EPICSSignalRO`, to represent it in in ophyd. In\n",
+    "EPICS, you just have to \"know\" this about your hardware. Fortunately if, in our\n",
+    "ignorance,  we used writable `ophyd.signal.EpicsSignal` instead, we could\n",
+    "still use it to read the PV. It would just have a vestigial ``set()`` method\n",
+    "that wouldn't work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fiscal-intersection",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ophyd.signal import EpicsSignalRO\n",
+    "\n",
+    "x = EpicsSignalRO(\"random_walk:x\", name=\"x\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "spectacular-qualification",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_delta.wait_for_connection()\n",
+    "x.wait_for_connection()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "checked-space",
+   "metadata": {},
+   "source": [
+    "## Use it with the Bluesky RunEngine\n",
+    "\n",
+    "The signals can be used by the Bluesky RunEngine. Let's configure a RunEngine\n",
+    "to print a table."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "affected-three",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bluesky import RunEngine\n",
+    "from bluesky.callbacks import LiveTable\n",
+    "RE = RunEngine()\n",
+    "token = RE.subscribe(LiveTable([\"time_delta\", \"x\"]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "blond-celebration",
+   "metadata": {},
+   "source": [
+    "Because ``time_delta`` is writable, it can be scanned like a \"motor\". It can\n",
+    "also be read like a \"detector\". (In Bluesky, all things that are \"motors\" are\n",
+    "also \"detectors\".)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "precious-corruption",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bluesky.plans import count, list_scan\n",
+    "\n",
+    "RE(count([time_delta]))  # Use as a \"detector\".\n",
+    "RE(list_scan([], time_delta, [0.1, 0.3, 1, 3]))  # Use as \"motor\"."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "failing-tribute",
+   "metadata": {},
+   "source": [
+    "For the following example, set ``time_delta`` to ``1``."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "induced-undergraduate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bluesky.plan_stubs import mv\n",
+    "\n",
+    "RE(mv(time_delta, 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "statistical-wagner",
+   "metadata": {},
+   "source": [
+    "We know that ``x`` represents a time-dependent variable. We can \"poll\" it at\n",
+    "regular intervals"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "treated-explosion",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RE(count([x], num=5, delay=0.5))  # Read every 0.5 seconds."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "administrative-moment",
+   "metadata": {},
+   "source": [
+    "but this required us to choose an update frequency (``0.5``). It's often better\n",
+    "to rely on the control system to *tell* us when a new value is available. In\n",
+    "this example, we accumulate updates for ``x`` whenever it changes."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "emerging-active",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bluesky.plan_stubs import monitor, unmonitor, open_run, close_run, sleep\n",
+    "\n",
+    "def monitor_x_for(duration, md=None):\n",
+    "   yield from open_run(md)  # optional metadata\n",
+    "   yield from monitor(x, name=\"x_monitor\")\n",
+    "   yield from sleep(duration)  # Wait for readings to accumulate.\n",
+    "   yield from unmonitor(x)\n",
+    "   yield from close_run()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "material-navigator",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "RE.unsubscribe(token)  # Remove the old table.\n",
+    "RE(monitor_x_for(3), LiveTable([\"x\"], stream_name=\"x_monitor\"))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "lesser-mayor",
+   "metadata": {},
+   "source": [
+    "If you are a scientist aiming to use Ophyd with the Bluesky Run Engine, you may\n",
+    "stop at this point or read on to learn more about how the Run Engine interacts\n",
+    "with these signals. If you are a controls engineer, the details that follow are\n",
+    "likely important to you.\n",
+    "\n",
+    "## Use it directly\n",
+    "\n",
+    "Note: These methods should *not* be called inside a Bluesky plan.\n",
+    "\n",
+    "### Read\n",
+    "\n",
+    "The signal can be read. It return a dictionary with one item. The key is the\n",
+    "human-friendly ``name`` we specified. The value is another dictionary,\n",
+    "containing the ``value`` and the ``timestamp`` of the reading from the control\n",
+    "system (in this case, EPICS)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "derived-funeral",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_delta.read()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "frank-activity",
+   "metadata": {},
+   "source": [
+    "### Describe\n",
+    "\n",
+    "Additional metadata is available. This always includes the data type, shape,\n",
+    "and source (e.g.  PV). It may also include units and other metadata."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "sharing-behavior",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_delta.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "powered-planning",
+   "metadata": {},
+   "source": [
+    "### Set\n",
+    "\n",
+    "This signal is writable, so it can also be set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "connected-grounds",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_delta.set(10).wait()  # Set it to 10 and wait for it to get there."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "annual-sponsorship",
+   "metadata": {},
+   "source": [
+    "Sometimes hardware gets stuck or does not do what it is told, and so it is good\n",
+    "practice to put a timeout on how long you are willing to wait until deciding\n",
+    "that there is an error that needs to be handled somehow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "beautiful-bottle",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_delta.set(10).wait(timeout=1)  # Set it to 10 and wait up to 1 second."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "growing-criminal",
+   "metadata": {},
+   "source": [
+    "If the signal fails to arrive, a ``TimeoutError`` will be raised.\n",
+    "\n",
+    "Note that ``set(...)`` starts the motion but does *not* wait for it to\n",
+    "complete. It is a fast, \"non-blocking\" operation. This enables you to run\n",
+    "code between starting a motion and completing it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "balanced-fundamental",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "status = time_delta.set(5)\n",
+    "print(\"Moving to 5...\")\n",
+    "status.wait(timeout=1)\n",
+    "print(\"Moved to 5.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "vertical-modification",
+   "metadata": {},
+   "source": [
+    "To move more than one signal in parallel, use the `ophyd.status.wait`\n",
+    "*function*.\n",
+    "\n",
+    "      from ophyd.status import wait\n",
+    "\n",
+    "      # Given signals a and b, set both in motion.\n",
+    "      status1 = a.set(1)\n",
+    "      status2 = b.set(1)\n",
+    "      # Wait for both to complete.\n",
+    "      wait(status1, status2, timeout=1)\n",
+    "\n",
+    "### Subscribe\n",
+    "\n",
+    "What's the best way to read a signal that changes over time, like our ``x``\n",
+    "signal?\n",
+    "\n",
+    "First, set ``time_delta`` to a reasonable value like ``1``. This controls the\n",
+    "update rate of ``x`` in our random walk simulation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sudden-australia",
+   "metadata": {},
+   "source": [
+    "time_delta.set(1).wait()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "polar-provider",
+   "metadata": {},
+   "source": [
+    "We could poll the signal in a loop and collect N readings spaced T seconds\n",
+    "apart."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "later-tonight",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "# Don't do this.\n",
+    "N = 5\n",
+    "T = 0.5\n",
+    "readings = []\n",
+    "for _ in range(N):\n",
+    "   time.sleep(T)\n",
+    "   reading = x.read()\n",
+    "   readings.append(reading)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "inner-american",
+   "metadata": {},
+   "source": [
+    "There are two problems with this counterexample.\n",
+    "\n",
+    "1. We might not know how often we need to check for updates.\n",
+    "2. We often want to watch *multiple* signals with different update rates, and\n",
+    "   this pattern would quickly become messy.\n",
+    "\n",
+    "Alternatively, we can use *subscription*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aware-middle",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from collections import deque\n",
+    "\n",
+    "def accumulate(value, old_value, timestamp, **kwargs):\n",
+    "   readings.append({\"x\": {\"value\": value, \"timestamp\": timestamp}})\n",
+    "\n",
+    "readings = deque(maxlen=5)\n",
+    "x.subscribe(accumulate)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "invisible-subject",
+   "metadata": {},
+   "source": [
+    "When the control system has a new ``reading`` for us, it calls\n",
+    "``readings.append(reading)`` from a background thread. If we do other work or\n",
+    "sleep for awhile and then check back on ``readings`` we'll see that it has some\n",
+    "items in it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "lyric-mount",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time.sleep(3)\n",
+    "readings"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "minute-michigan",
+   "metadata": {},
+   "source": [
+    "It will keep the last ``5``. We used a `collections.deque` instead of a\n",
+    "plain `list` here because a `list` would grow without bound and, if left to\n",
+    "run long enough, consume all available memory, crashing the program."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/_toc.yml
+++ b/_toc.yml
@@ -5,6 +5,8 @@ parts:
   chapters:
   - file: Hello Python and Jupyter
   - file: Hello Bluesky
+  - file: Single PVs
+  - file: Group Signals into Devices
 - caption: About
   chapters:
   - file: CONTRIBUTING

--- a/supervisor/conf.d/random_walk_horiz.conf
+++ b/supervisor/conf.d/random_walk_horiz.conf
@@ -1,5 +1,5 @@
 [program:random_walk_horiz]
-command = /usr/bin/env python3 -m caproto.ioc_examples.random_walk -v --interfaces=0.0.0.0 --prefix="random_walk:horiz-"
+command = /usr/bin/env python3 -m caproto.ioc_examples.random_walk -v --interfaces=0.0.0.0 --prefix="random-walk:horiz:"
 stdout_logfile = /tmp/random_walk_horiz_stdout.log
 stderr_logfile = /tmp/random_walk_horiz_stderr.log
 stopasgroup = true

--- a/supervisor/conf.d/random_walk_vert.conf
+++ b/supervisor/conf.d/random_walk_vert.conf
@@ -1,5 +1,5 @@
 [program:random_walk_vert]
-command = /usr/bin/env python3 -m caproto.ioc_examples.random_walk -v --interfaces=0.0.0.0 --prefix="random_walk:vert-"
+command = /usr/bin/env python3 -m caproto.ioc_examples.random_walk -v --interfaces=0.0.0.0 --prefix="random-walk:vert:"
 stdout_logfile = /tmp/random_walk_vert_stdout.log
 stderr_logfile = /tmp/random_walk_vert_stderr.log
 stopasgroup = true


### PR DESCRIPTION
This adds "Single PVs" and "Group Signals into Devices", transcribed (by hand) from .rst files in the ophyd docs, with the

```
.. ipython: python
```

blocks changed to code cells.

(There are apparently automated ways to do this, but none officially supported by Jupyter tools, and none that looks sure to be easier than transcribing by hand.)