### PR TITLE
Aim the default_url to JupyterLab, not classic.

### DIFF
--- a/.jupyter/jupyter_notebook_config.py
+++ b/.jupyter/jupyter_notebook_config.py
@@ -1,0 +1,1 @@
+c.NotebookApp.default_url = "lab"

--- a/binder/start
+++ b/binder/start
@@ -27,5 +27,6 @@ fi
 # It is not yet clear why.
 export EPICS_CA_AUTO_ADDR_LIST=no
 export EPICS_CA_ADDR_LIST=255.255.255.255
+export JUPYTER_CONFIG_DIR=./.jupyter/
 
 exec "$@"


### PR DESCRIPTION
This results in

```
jupyter-repo2docker --editable .
```

aiming the user's browser at Jupyter _Lab_ by default, without any change to the Contributing instructions. :tada: 