### PR TITLE
Use nbdime integration.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,3 @@
 *.ipynb filter=nbstripout
-*.ipynb diff=ipynb
-
 *.ipynb	diff=jupyternotebook
-
 *.ipynb	merge=jupyternotebook

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,6 @@
 *.ipynb filter=nbstripout
 *.ipynb diff=ipynb
+
+*.ipynb	diff=jupyternotebook
+
+*.ipynb	merge=jupyternotebook

--- a/binder/requirements-dev.txt
+++ b/binder/requirements-dev.txt
@@ -1,4 +1,5 @@
 jupyter-repo2docker
 six  # looks like it's an undeclared dependency of docker Python bindings
+nbdime
 nbstripout
 pre-commit


### PR DESCRIPTION
[nbdime](https://nbdime.readthedocs.io/en/latest/index.html) is Jupyter's officially-supported solution for diffing and merging ("diff + merge" --> "dime") Jupyter notebook documents. Integrating deeply with git, it ensures that the result of a diff or merge operation on a notebook results in another valid notebook. Raw text-based diff and merge can easily result in a file that is not valid JSON or not a valid notebook document.

It also makes the output of `git diff` more readable. Example:

```diff
## inserted before /cells/11:
+  code cell:
+    source:
+      status = decay.set(120)
+      status.wait()  # blocks here
+      print("DONE!")

## deleted /cells/11:
-  code cell:
-    source:
-      status = decay.set(120)
-      
-      import time
-      while not status.done:
-          time.sleep(0.01)  # Make sure to sleep to avoid pinning CPU.
-      print("DONE!")

## modified /cells/12/id:
-  linear-provision
+  bright-armstrong

## modified /cells/13/id:
-  adjusted-empire
+  attached-calculator

## modified /cells/13/source:
@@ -18,7 +18,7 @@ class Decay(Device):
         # when the readback approaches within some tolerance of the setpoint.
         def callback(old_value, value, **kwargs):
             if abs(value - setpoint) < self.tolerance.get():
-                status._finished()
+                status.set_finished()
                 self.readback.clear_sub(callback)
             
         self.readback.subscribe(callback)
```