### PR TITLE
BLD: flexible requirements for compat with 3.10

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -20,11 +20,11 @@ kiwisolver <1.2
 lmfit
 matplotlib >=3.4
 nbgitpuller
-numpy <1.20
+numpy #<1.20
 ophyd
 ophyd
 pandas
-protobuf <=3.20
+protobuf <=3.20.1
 pyepics
 scikit-image
 suitcase-csv
@@ -33,7 +33,7 @@ suitcase-mongo
 suitcase-msgpack
 suitcase-tiff
 supervisor
-tensorboard==2.2.1
-tensorflow==2.2.0
-tensorforce==0.5.5
+tensorflow == 2.8.0
+tensorboard
+tensorforce
 toolz==0.10.0

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -24,7 +24,7 @@ numpy #<1.20
 ophyd
 ophyd
 pandas
-protobuf <=3.20.1
+protobuf <=3.20.1 # Required for tf 2.8.0
 pyepics
 scikit-image
 suitcase-csv
@@ -33,7 +33,7 @@ suitcase-mongo
 suitcase-msgpack
 suitcase-tiff
 supervisor
-tensorflow == 2.8.0
+tensorflow == 2.8.0 # Required for tensorboard
 tensorboard
 tensorforce
 toolz==0.10.0

--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8
+python-3.10


### PR DESCRIPTION
- removed np version, requires preemptive install as outlined in INSTALLATION.MD
- Tensorflow is trapped by tensorforce. Protobuf is in turn trapped by tensorflow. 
- This was tested with a local venv using pip install from a python 3.10.9 interpreter.