### PR TITLE
BLD: Py310 remove reinforcement learning explicitly

### DIFF
--- a/Adaptive RL Sampling/Adaptive Sampling.ipynb
+++ b/Adaptive RL Sampling/Adaptive Sampling.ipynb
@@ -170,7 +170,7 @@
    "source": [
     "def select_sample(sample_number, *, verbose=False):\n",
     "    if verbose:\n",
-    "        print(f'Moving to sample {sample_number}')\n",
+    "        print(f\"Moving to sample {sample_number}\")\n",
     "    yield from mv(sample_selector, sample_number)"
    ]
   },
@@ -329,7 +329,7 @@
    "source": [
     "def multi_count(num_counts):\n",
     "    for i in range(num_counts):\n",
-    "        print(f'Exposure number {i}')\n",
+    "        print(f\"Exposure number {i}\")\n",
     "        yield from count([sample_selector, detector])"
    ]
   },
@@ -380,7 +380,7 @@
    "source": [
     "def multi_sample_plan(measure_ratio, total_loops=1):\n",
     "    for i in range(total_loops):\n",
-    "        print(f'* Now on big loop {i}')\n",
+    "        print(f\"* Now on big loop {i}\")\n",
     "        yield from select_sample(0, verbose=True)\n",
     "        yield from count([sample_selector, detector])\n",
     "        yield from select_sample(1, verbose=True)\n",
@@ -596,7 +596,8 @@
    "id": "6c8a5a71",
    "metadata": {},
    "source": [
-    "Note that the data collection will take slightly longer to get started as the RL agent must be loaded.  However, from the standpoint of interfacing with Bluesky, we are again using the `Bluesky-adaptive` machinery and the `with_agent` helper plan."
+    "Note: Here we replace the RL agent with a lightweight Monte Carlo approximation. This enables this tutorial to run quickly, overcomes challenges with outdated versioning of the agent, and retains the Tensorforce agent code in this repository as an example. \n",
+    "Nonetheless, from the standpoint of interfacing with Bluesky, we are again using the `Bluesky-adaptive` machinery and the `with_agent` helper plan."
    ]
   },
   {
@@ -607,9 +608,10 @@
    "outputs": [],
    "source": [
     "from utils.adaptive_recommendations import RLAgent\n",
+    "\n",
     "detector.delay = 1\n",
     "unique_ids = RE(\n",
-    "    with_agent(RLAgent(9, 'tf_models/bluesky-tutorial/saved_models'), max_shots=90),\n",
+    "    with_agent(RLAgent(9, \"tf_models/bluesky-tutorial/saved_models\"), max_shots=90),\n",
     "    callback,\n",
     ")"
    ]
@@ -701,10 +703,10 @@
    "source": [
     "import random\n",
     "\n",
+    "\n",
     "def chaos_agent(x, y):\n",
     "    # ignores input!\n",
-    "    return random.choice(range(9))\n",
-    "\n"
+    "    return random.choice(range(9))"
    ]
   },
   {

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -20,11 +20,10 @@ kiwisolver <1.2
 lmfit
 matplotlib >=3.4
 nbgitpuller
-numpy #<1.20
+numpy
 ophyd
 ophyd
 pandas
-protobuf <=3.20.1 # Required for tf 2.8.0
 pyepics
 scikit-image
 suitcase-csv
@@ -33,7 +32,4 @@ suitcase-mongo
 suitcase-msgpack
 suitcase-tiff
 supervisor
-tensorflow == 2.8.0 # Required for tensorboard
-tensorboard
-tensorforce
 toolz==0.10.0

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -20,11 +20,11 @@ kiwisolver <1.2
 lmfit
 matplotlib >=3.4
 nbgitpuller
-numpy <1.20
+numpy #<1.20
 ophyd
 ophyd
 pandas
-protobuf <=3.20
+protobuf <=3.20.1
 pyepics
 scikit-image
 suitcase-csv
@@ -33,7 +33,7 @@ suitcase-mongo
 suitcase-msgpack
 suitcase-tiff
 supervisor
-tensorboard==2.2.1
-tensorflow==2.2.0
-tensorforce==0.5.5
+tensorflow == 2.8.0
+tensorboard
+tensorforce
 toolz==0.10.0

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -15,6 +15,7 @@ ipykernel
 ipympl >=0.6.3
 ipywidgets <7.7
 jupyter-book
+jupyter-cache < 0.5
 jupyterlab >=3
 kiwisolver <1.2
 lmfit

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -20,6 +20,9 @@ kiwisolver <1.2
 lmfit
 matplotlib >=3.4
 nbgitpuller
+# jupyter/nbconvert#1970 for the 7.3 series exclusions
+nbconvert[execute]!=6.0.0,!=6.0.1,!=7.3.0,!=7.3.1
+nbformat!=5.0.0,!=5.0.1
 numpy
 ophyd
 ophyd

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -24,7 +24,7 @@ numpy #<1.20
 ophyd
 ophyd
 pandas
-protobuf <=3.20.1
+protobuf <=3.20.1 # Required for tf 2.8.0
 pyepics
 scikit-image
 suitcase-csv
@@ -33,7 +33,7 @@ suitcase-mongo
 suitcase-msgpack
 suitcase-tiff
 supervisor
-tensorflow == 2.8.0
+tensorflow == 2.8.0 # Required for tensorboard
 tensorboard
 tensorforce
 toolz==0.10.0

--- a/binder/runtime.txt
+++ b/binder/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8
+python-3.10


### PR DESCRIPTION
This goes a step beyond #133. Instead of trying to patch the `tensorforce` and `tensorflow` requirements, we leave the code as an example, but define the tutorials without those dependencies. The RL agent has been replaced in the notebook by a lightweight monte carlo walk. 